### PR TITLE
Made `XMLEncoder.OutputFormatting.prettyPrinted` actually do something

### DIFF
--- a/Sources/XMLParsing/Encoder/XMLEncoder.swift
+++ b/Sources/XMLParsing/Encoder/XMLEncoder.swift
@@ -250,8 +250,9 @@ open class XMLEncoder {
         guard let element = _XMLElement.createRootElement(rootKey: rootKey, object: topLevel) else {
             throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Unable to encode the given top-level value to XML."))
         }
-        
-        return element.toXMLString(with: header, withCDATA: stringEncodingStrategy != .deferredToString).data(using: .utf8, allowLossyConversion: true)!
+
+        let withCDATA = stringEncodingStrategy != .deferredToString
+        return element.toXMLString(with: header, withCDATA: withCDATA, formatting: self.outputFormatting).data(using: .utf8, allowLossyConversion: true)!
     }
 }
 

--- a/Sources/XMLParsing/XMLStackParser.swift
+++ b/Sources/XMLParsing/XMLStackParser.swift
@@ -192,16 +192,18 @@ internal class _XMLElement {
         return node
     }
     
-    func toXMLString(with header: XMLHeader? = nil, withCDATA cdata: Bool, ignoreEscaping: Bool = false) -> String {
+    func toXMLString(with header: XMLHeader? = nil, withCDATA cdata: Bool, formatting: XMLEncoder.OutputFormatting, ignoreEscaping: Bool = false) -> String {
         if let header = header, let headerXML = header.toXML() {
-            return headerXML + _toXMLString(withCDATA: cdata)
+            return headerXML + _toXMLString(withCDATA: cdata, formatting: formatting)
         } else {
-            return _toXMLString(withCDATA: cdata)
+            return _toXMLString(withCDATA: cdata, formatting: formatting)
         }
     }
     
-    fileprivate func _toXMLString(indented level: Int = 0, withCDATA cdata: Bool, ignoreEscaping: Bool = false) -> String {
-        var string = String(repeating: " ", count: level * 4)
+    fileprivate func _toXMLString(indented level: Int = 0, withCDATA cdata: Bool, formatting: XMLEncoder.OutputFormatting, ignoreEscaping: Bool = false) -> String {
+        let prettyPrinted = formatting.contains(.prettyPrinted)
+        let indentation = String(repeating: " ", count: (prettyPrinted ? level : 0) * 4)
+        var string = indentation
         string += "<\(key)"
         
         for (key, value) in attributes {
@@ -217,16 +219,16 @@ internal class _XMLElement {
             }
             string += "</\(key)>"
         } else if !children.isEmpty {
-            string += ">\n"
+            string += prettyPrinted ? ">\n" : ">"
             
             for childElement in children {
                 for child in childElement.value {
-                    string += child._toXMLString(indented: level + 1, withCDATA: cdata)
-                    string += "\n"
+                    string += child._toXMLString(indented: level + 1, withCDATA: cdata, formatting: formatting)
+                    string += prettyPrinted ? "\n" : ""
                 }
             }
             
-            string += String(repeating: " ", count: level * 4)
+            string += indentation
             string += "</\(key)>"
         } else {
             string += " />"


### PR DESCRIPTION
There's not much use in having a `.prettyPrinted` option if it isn't considered anywhere. 😄