### PR TITLE
Added support for decoupled, type-dependent node-encoding strategies

### DIFF
--- a/Sources/XMLParsing/Encoder/XMLReferencingEncoder.swift
+++ b/Sources/XMLParsing/Encoder/XMLReferencingEncoder.swift
@@ -35,20 +35,36 @@ internal class _XMLReferencingEncoder : _XMLEncoder {
     // MARK: - Initialization
     
     /// Initializes `self` by referencing the given array container in the given encoder.
-    internal init(referencing encoder: _XMLEncoder, at index: Int, wrapping array: NSMutableArray) {
+    internal init(
+        referencing encoder: _XMLEncoder,
+        at index: Int,
+        wrapping array: NSMutableArray
+    ) {
         self.encoder = encoder
         self.reference = .array(array, index)
-        super.init(options: encoder.options, codingPath: encoder.codingPath)
+        super.init(
+            options: encoder.options,
+            nodeEncodings: encoder.nodeEncodings,
+            codingPath: encoder.codingPath
+        )
         
         self.codingPath.append(_XMLKey(index: index))
     }
     
     /// Initializes `self` by referencing the given dictionary container in the given encoder.
-    internal init(referencing encoder: _XMLEncoder,
-                     key: CodingKey, convertedKey: CodingKey, wrapping dictionary: NSMutableDictionary) {
+    internal init(
+        referencing encoder: _XMLEncoder,
+        key: CodingKey,
+        convertedKey: CodingKey,
+        wrapping dictionary: NSMutableDictionary
+    ) {
         self.encoder = encoder
         self.reference = .dictionary(dictionary, convertedKey.stringValue)
-        super.init(options: encoder.options, codingPath: encoder.codingPath)
+        super.init(
+            options: encoder.options,
+            nodeEncodings: encoder.nodeEncodings,
+            codingPath: encoder.codingPath
+        )
         
         self.codingPath.append(key)
     }


### PR DESCRIPTION
The current way that `AttributeEncodingStrategy` is implemented does not allow for compositional strategy delegation.

After a bit of a redesign `XMLParsing` now supports this (while remaining the option to keep doing it the current way):

```swift
struct Foo: Codable {
    let title: String

    let bar: Bar
}

struct Bar: Codable {
    let title: String

    let baz: Baz
}

struct Baz: Codable {
    let title: String
}

protocol XMLNodeEncodingStrategy {
    static func nodeEncoding(forKey codingKey: CodingKey) -> XMLEncoder.NodeEncoding
}

extension Foo: XMLNodeEncodingStrategy {
    static func nodeEncoding(forKey codingKey: CodingKey) -> XMLEncoder.NodeEncoding {
        switch codingKey.stringValue {
        case "title": return .attribute
        default: return .default
        }
    }
}

extension Baz: XMLNodeEncodingStrategy {
    static func nodeEncoding(forKey codingKey: CodingKey) -> XMLEncoder.NodeEncoding {
        switch codingKey.stringValue {
        case "title": return .attribute
        default: return .default
        }
    }
}
```

Note that the `XMLNodeEncodingStrategy` protocol here is user-specified and you're free to do things your own way (i.e. nobody forces one to add the node encoding strategy to the encodable value type itself, you're free to put it in a dedicated encoding strategy, which could then also be shared across values).

I personally prefer to have small neatly scoped encoding strategies that can easily be composed. But if one wishes to use a plain closure as strategy, there's nothing holding one up from doing so:

```swift
let nodeEncodingStrategy: (Encodable.Type, Encoder) -> ((CodingKey) -> XMLEncoder.NodeEncoding) = { codableType, encoder in
    switch codableType {
    case is Foo.Type, is Baz.Type:
        return { codingKey in
            switch codingKey.stringValue {
            case "title": return .attribute
            default: return .default
            }
        }
    default:
        return { _ in return .default }
    }
}
```

Either way using the above API like this …

```swift
let foo = Foo(
    title: "foo",
    bar: Bar(
        title: "bar",
        baz: Baz(
            title: "baz"
        )
    )
)

let encoder = XMLEncoder()
encoder.outputFormatting = [.prettyPrinted]
encoder.nodeEncodingStrategy = .custom { codableType, encoder in
    guard let strategy = codableType as? XMLNodeEncodingStrategy.Type else {
        return { _ in return .default }
    }
    return strategy.nodeEncoding(forKey:)
}

let encoded = try encoder.encode(foo, withRootKey: "foo")
```
… produces an output like this:

```xml
<foo title="foo">
    <bar>
        <title>bar</title>
        <baz title="baz" />
    </bar>
</foo>
```