### PR TITLE
Add tvOS deployment target to podspec

### DIFF
--- a/XMLParsing.podspec
+++ b/XMLParsing.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author       = { "Shawn Moore" => "sm5@me.com" }
   s.ios.deployment_target = "10.0"
+  s.tvos.deployment_target = "10.0"
   s.osx.deployment_target = "10.12"
   s.source       = { :git => "https://github.com/ShawnMoore/XMLParsing.git", :tag => s.version.to_s }
   s.source_files = "Sources/XMLParsing/**/*.swift"


### PR DESCRIPTION
Adds a tvOS deployment target to allow this library's use in tvOS projects